### PR TITLE
Add precomputed planes feature

### DIFF
--- a/cfg/PlaneCalibration.cfg
+++ b/cfg/PlaneCalibration.cfg
@@ -11,7 +11,10 @@ gen.add("input_max_zero_ratio", double_t, 0, "Max. ratio of zeros to consider va
 gen.add("input_min_data_ratio", double_t, 0, "Min. ratio of valid overall data to consider valid input data", 0.6, 0.0, 1.0)
 
 gen.add("max_deviation_degrees", double_t, 0, "Max. deviation of the ground plane orientation [degree]", 6.0, 0.0, 14.0)
-gen.add("iterations", int_t, 0, "Iterations to optimize estimation", 3, 0, 20)
+gen.add("iterations", int_t, 0, "Iterations to optimize estimation", 4, 0, 20)
+
+gen.add("precompute_planes", bool_t, 0, "Precompute planes for fitting or calculate on the fly", True)
+gen.add("precomputed_plane_pairs_count", int_t, 0, "Iterations to optimize estimation", 20, 1, 100)
 
 gen.add("plane_max_too_low_ratio", double_t, 0, "[Validation] Max. ratio of points lower than given ground plane to consider fitting the data", 0.12, 0.0, 1.0)
 gen.add("plane_max_mean", double_t, 0, "[Validation] Max. mean data point abs. distance to given ground plane to consider fitting the data", 0.024, 0.0, 0.2)
@@ -19,6 +22,7 @@ gen.add("plane_max_deviation", double_t, 0, "[Validation] Max. deviation of any 
 
 gen.add("debug", bool_t, 0, "Show debug things, e.g. tf transforms", False)
 gen.add("use_manual_ground_transform", bool_t, 0, "Use the settings below for the ground plane transformation", False)
+gen.add("always_update", bool_t, 0, "Update calibration even if old calibration looks fine", False)
 
 gen.add("x", double_t, 0, "x offset", 0.0, -2.0, 2.0)
 gen.add("y", double_t, 0, "y offset", 0.3, -2.0, 2.0)

--- a/include/plane_calibration/calibration_parameters.hpp
+++ b/include/plane_calibration/calibration_parameters.hpp
@@ -20,15 +20,19 @@ public:
       rotation_ = Eigen::AngleAxisd::Identity();
       max_deviation_ = 0.0;
       deviation_ = 0.0;
+      precompute_planes_ = true;
+      precomputed_plane_pairs_count_ = 0;
     }
 
     Parameters(const double& max_deviation, const Eigen::Vector3d& ground_plane_offset,
-               const Eigen::AngleAxisd& rotation = Eigen::AngleAxisd::Identity())
+               const Eigen::AngleAxisd& rotation, bool precompute_planes, int precomputed_plane_pairs_count)
     {
       ground_plane_offset_ = ground_plane_offset;
       rotation_ = rotation;
       max_deviation_ = max_deviation;
       deviation_ = max_deviation_;
+      precompute_planes_ = precompute_planes;
+      precomputed_plane_pairs_count_ = precomputed_plane_pairs_count;
     }
 
     Eigen::Affine3d getTransform() const
@@ -41,11 +45,14 @@ public:
 
     double max_deviation_;
     double deviation_;
+
+    bool precompute_planes_;
+    int precomputed_plane_pairs_count_;
   };
 
-  CalibrationParameters();
+  CalibrationParameters(bool precompute_planes, int precomputed_plane_pairs_count);
   CalibrationParameters(const double& max_deviation, const Eigen::Vector3d& ground_plane_offset,
-                        const Eigen::AngleAxisd& rotation = Eigen::AngleAxisd::Identity());
+                        const Eigen::AngleAxisd& rotation, bool precompute_planes, int precomputed_plane_pairs_count);
   CalibrationParameters(const CalibrationParameters &object);
 
   bool getUpdatedParameters(Parameters& updated_parameters);

--- a/include/plane_calibration/calibration_parameters.hpp
+++ b/include/plane_calibration/calibration_parameters.hpp
@@ -69,6 +69,7 @@ public:
   void update(const Eigen::AngleAxisd& rotation);
   void update(const double& deviation);
   void updateDeviations(const double& value);
+  void updatePrecomputation(const bool& enable, const int& plane_pair_count);
 
   void updateDeviation(const double& deviation);
 

--- a/include/plane_calibration/plane_calibration.hpp
+++ b/include/plane_calibration/plane_calibration.hpp
@@ -41,8 +41,6 @@ protected:
   PlaneToDepthImage plane_to_depth_;
   DeviationPlanesPtr max_deviation_planes_;
 
-  bool precompute_planes_;
-  int precomputed_plane_pairs_count_;
   PlanesPtr precomputed_planes_;
 
   std::vector<DeviationPlanesPtr> deviation_planes_;

--- a/include/plane_calibration/plane_calibration.hpp
+++ b/include/plane_calibration/plane_calibration.hpp
@@ -10,6 +10,7 @@
 #include "camera_model.hpp"
 #include "calibration_parameters.hpp"
 #include "deviation_planes.hpp"
+#include "planes.hpp"
 #include "visualizer_interface.hpp"
 
 namespace plane_calibration
@@ -28,6 +29,10 @@ public:
   std::pair<double, double> calibrate(const Eigen::MatrixXf& filtered_depth_matrix, const int& iterations = 3);
 
 protected:
+  std::pair<double, double> estimateAngles(const Eigen::MatrixXf& filtered_depth_matrix,
+                                           const std::pair<double, double>& last_estimation, const double& deviation);
+  std::pair<double, double> estimateAngles(const Eigen::MatrixXf& filtered_depth_matrix, const double& x_angle_offset,
+                                           const double& y_angle_offset, const double& deviation);
 
   mutable std::mutex mutex_;
   CameraModel camera_model_;
@@ -36,6 +41,13 @@ protected:
   PlaneToDepthImage plane_to_depth_;
   DeviationPlanesPtr max_deviation_planes_;
 
+  bool precompute_planes_;
+  int precomputed_plane_pairs_count_;
+  PlanesPtr precomputed_planes_;
+
+  std::vector<DeviationPlanesPtr> deviation_planes_;
+
+  CalibrationParameters::Parameters temp_parameters_;
   DeviationPlanesPtr temp_deviation_planes_;
   Eigen::MatrixXf temp_estimated_plane_;
 

--- a/include/plane_calibration/plane_calibration_nodelet.hpp
+++ b/include/plane_calibration/plane_calibration_nodelet.hpp
@@ -80,6 +80,7 @@ protected:
 
   std::atomic<bool> debug_;
   std::atomic<bool> use_manual_ground_transform_;
+  std::atomic<bool> always_update_;
   std::atomic<double> x_offset_;
   std::atomic<double> y_offset_;
   std::atomic<double> z_offset_;

--- a/include/plane_calibration/plane_calibration_nodelet.hpp
+++ b/include/plane_calibration/plane_calibration_nodelet.hpp
@@ -48,6 +48,9 @@ protected:
 
   ros::Time last_call_time_;
   double calibration_rate_;
+
+  bool precompute_planes_;
+  int precomputed_plane_pairs_count_;
   CameraModelPtr camera_model_;
   CalibrationParametersPtr calibration_parameters_;
 

--- a/include/plane_calibration/planes.hpp
+++ b/include/plane_calibration/planes.hpp
@@ -16,8 +16,7 @@ typedef std::shared_ptr<Eigen::MatrixXf> MatrixPlanePtr;
 class Planes
 {
 public:
-  Planes(const int& count, const CalibrationParameters::Parameters& parameters,
-         const PlaneToDepthImage& plane_to_depth);
+  Planes(const CalibrationParameters::Parameters& parameters, const PlaneToDepthImage& plane_to_depth);
 
   std::pair<MatrixPlanePtr, MatrixPlanePtr> getFittingXTiltPlanes(const double& angle, const double& deviation);
   std::pair<MatrixPlanePtr, MatrixPlanePtr> getFittingYTiltPlanes(const double& angle, const double& deviation);

--- a/include/plane_calibration/planes.hpp
+++ b/include/plane_calibration/planes.hpp
@@ -1,0 +1,50 @@
+#ifndef plane_calibration_SRC_PLANES_HPP_
+#define plane_calibration_SRC_PLANES_HPP_
+
+#include <memory>
+#include <map>
+#include <utility>
+#include <Eigen/Dense>
+
+#include "calibration_parameters.hpp"
+#include "plane_to_depth_image.hpp"
+
+namespace plane_calibration
+{
+typedef std::shared_ptr<Eigen::MatrixXf> MatrixPlanePtr;
+
+class Planes
+{
+public:
+  Planes(const int& count, const CalibrationParameters::Parameters& parameters,
+         const PlaneToDepthImage& plane_to_depth);
+
+  std::pair<MatrixPlanePtr, MatrixPlanePtr> getFittingXTiltPlanes(const double& angle, const double& deviation);
+  std::pair<MatrixPlanePtr, MatrixPlanePtr> getFittingYTiltPlanes(const double& angle, const double& deviation);
+
+protected:
+  void makePlanes();
+  Eigen::MatrixXf makePlane(const Eigen::Vector2d& angles);
+
+  void addPlanePairs(const double& angle);
+  void addPlanes(const double& angle);
+
+  std::pair<MatrixPlanePtr, MatrixPlanePtr> getFittingTiltPlanes(const std::map<double, MatrixPlanePtr>& planes,
+                                                                 const double& angle, const double& deviation);
+  std::pair<double, double> getDeviationPlaneKeys(const double& angle, const double& deviation);
+
+  int pair_count_;
+  double max_deviation_;
+  PlaneToDepthImage plane_to_depth_;
+
+  Eigen::Translation3d translation_;
+  Eigen::AngleAxisd base_rotation_;
+
+  std::map<double, MatrixPlanePtr> x_planes_;
+  std::map<double, MatrixPlanePtr> y_planes_;
+};
+typedef std::shared_ptr<Planes> PlanesPtr;
+
+} /* end namespace */
+
+#endif

--- a/launch/nodelet.launch.xml
+++ b/launch/nodelet.launch.xml
@@ -9,7 +9,8 @@
   <node pkg="nodelet" type="nodelet" name="plane_calibration" args="load plane_calibration/PlaneCalibrationNodelet $(arg nodelet_manager_name)">
     <param name="camera_depth_frame"                        value="$(arg camera_depth_frame)"/>
     <param name="result_camera_depth_frame"                 value="$(arg result_camera_depth_frame)"/>
-    <rosparam file="$(arg parameter_file_path)"             command="load"/>
+    <rosparam file="$(find plane_calibration)/params/defaults.yaml"     command="load"/>
+    <rosparam file="$(arg parameter_file_path)"                         command="load"/>
     <remap from="plane_calibration/camera_info"             to="$(arg camera_info_topic)"/>
     <remap from="plane_calibration/input_depth_image"       to="$(arg input_depth_image_topic)"/>
   </node>

--- a/params/defaults.yaml
+++ b/params/defaults.yaml
@@ -1,2 +1,4 @@
 calibration_rate:           1.0
 ground_frame:               base_footprint
+precompute_planes:         true
+precomputed_plane_pairs_count:  20

--- a/src/calibration_parameters.cpp
+++ b/src/calibration_parameters.cpp
@@ -112,6 +112,14 @@ void CalibrationParameters::updateDeviations(const double& value)
   updated_ = true;
 }
 
+void CalibrationParameters::updatePrecomputation(const bool& enable, const int& plane_pair_count)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  parameters_.precompute_planes_ = enable;
+  parameters_.precomputed_plane_pairs_count_ = plane_pair_count;
+  updated_ = true;
+}
+
 void CalibrationParameters::updateDeviation(const double& deviation)
 {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/src/calibration_parameters.cpp
+++ b/src/calibration_parameters.cpp
@@ -2,18 +2,24 @@
 
 namespace plane_calibration
 {
-CalibrationParameters::CalibrationParameters()
+CalibrationParameters::CalibrationParameters(bool precompute_planes, int precomputed_plane_pairs_count)
 {
+  parameters_.precompute_planes_ = precompute_planes;
+  parameters_.precomputed_plane_pairs_count_ = precomputed_plane_pairs_count;
   updated_ = true;
 }
 
 CalibrationParameters::CalibrationParameters(const double& max_deviation, const Eigen::Vector3d& ground_plane_offset,
-                                             const Eigen::AngleAxisd& rotation)
+                                             const Eigen::AngleAxisd& rotation, bool precompute_planes,
+                                             int precomputed_plane_pairs_count)
 {
   parameters_.ground_plane_offset_ = ground_plane_offset;
   parameters_.max_deviation_ = max_deviation;
   parameters_.deviation_ = parameters_.max_deviation_;
   parameters_.rotation_ = rotation;
+
+  parameters_.precompute_planes_ = precompute_planes;
+  parameters_.precomputed_plane_pairs_count_ = precomputed_plane_pairs_count;
   updated_ = true;
 }
 

--- a/src/plane_calibration.cpp
+++ b/src/plane_calibration.cpp
@@ -22,13 +22,10 @@ PlaneCalibration::PlaneCalibration(const CameraModel& camera_model, const Calibr
   temp_deviation_planes_ = std::make_shared<DeviationPlanes>(plane_to_depth_, depth_visualizer);
 
   depth_visualizer_ = depth_visualizer;
-  precompute_planes_ = true;
-  precomputed_plane_pairs_count_ = 20;
 
-  if (precompute_planes_)
+  if (parameters->getParameters().precompute_planes_)
   {
-    precomputed_planes_ = std::make_shared<Planes>(precomputed_plane_pairs_count_, parameters_->getParameters(),
-                                                   plane_to_depth_);
+    precomputed_planes_ = std::make_shared<Planes>(parameters_->getParameters(), plane_to_depth_);
   }
 }
 
@@ -43,8 +40,7 @@ std::pair<double, double> PlaneCalibration::calibrate(const Eigen::MatrixXf& fil
   if (parameters_updated)
   {
     max_deviation_planes_->update(updated_parameters);
-    precomputed_planes_ = std::make_shared<Planes>(precomputed_plane_pairs_count_, parameters_->getParameters(),
-                                                   plane_to_depth_);
+    precomputed_planes_ = std::make_shared<Planes>(parameters_->getParameters(), plane_to_depth_);
   }
 
   double x_angle_offset = 0.0;
@@ -70,7 +66,7 @@ std::pair<double, double> PlaneCalibration::calibrate(const Eigen::MatrixXf& fil
   {
     double max_angle_deviation = std::max(std::abs(angle_offset_estimation.first),
                                           std::abs(angle_offset_estimation.second));
-    if (!precompute_planes_)
+    if (!temp_parameters_.precompute_planes_)
     {
       angle_offset_estimation = estimateAngles(filtered_depth_matrix, angle_offset_estimation, max_angle_deviation);
     }

--- a/src/plane_calibration.cpp
+++ b/src/plane_calibration.cpp
@@ -52,7 +52,7 @@ std::pair<double, double> PlaneCalibration::calibrate(const Eigen::MatrixXf& fil
   x_angle_offset += angle_offset_estimation.first;
   y_angle_offset += angle_offset_estimation.second;
 
-//  std::cout << "max_angle_deviation: " << ecl::radians_to_degrees(parameters.deviation_) << std::endl;
+//  std::cout << "max_angle_deviation: " << ecl::radians_to_degrees(temp_parameters_.deviation_) << std::endl;
 //  std::cout << "0 angles : " << ecl::radians_to_degrees(angle_offset_estimation.first) << ", "
 //      << ecl::radians_to_degrees(angle_offset_estimation.second) << std::endl;
 //  std::cout << "0 full   : " << ecl::radians_to_degrees(x_angle_offset) << ", "

--- a/src/plane_calibration_nodelet.cpp
+++ b/src/plane_calibration_nodelet.cpp
@@ -25,6 +25,9 @@ PlaneCalibrationNodelet::PlaneCalibrationNodelet() :
   use_manual_ground_transform_ = false;
   ground_plane_rotation_ = Eigen::AngleAxisd::Identity();
 
+  precompute_planes_ = true;
+  precomputed_plane_pairs_count_ = 20;
+
   last_valid_calibration_result_ = std::make_pair(0.0, 0.0);
 
   Eigen::AngleAxisd rotation;
@@ -47,6 +50,9 @@ void PlaneCalibrationNodelet::onInit()
 
   node_handle.param("calibration_rate", calibration_rate_, 1.0);
   node_handle.param("ground_frame", ground_frame_, std::string("base_footprint"));
+  node_handle.param("precompute_planes", precompute_planes_, true);
+  node_handle.param("precomputed_plane_pairs_count", precomputed_plane_pairs_count_, 20);
+
   node_handle.param("camera_depth_frame", camera_depth_frame_, std::string("camera_depth_optical_frame"));
   node_handle.param("result_camera_depth_frame", result_frame_, std::string("ground_plane_frame"));
 
@@ -95,7 +101,8 @@ void PlaneCalibrationNodelet::reconfigureCB(PlaneCalibrationConfig &config, uint
 
   if (!calibration_parameters_)
   {
-    calibration_parameters_ = std::make_shared<CalibrationParameters>();
+    calibration_parameters_ = std::make_shared<CalibrationParameters>(precompute_planes_,
+                                                                      precomputed_plane_pairs_count_);
   }
 
   calibration_parameters_->updateDeviations(ecl::degrees_to_radians(config.max_deviation_degrees));

--- a/src/planes.cpp
+++ b/src/planes.cpp
@@ -1,0 +1,109 @@
+#include "plane_calibration/planes.hpp"
+
+#include <cmath>
+#include <iostream>
+
+namespace plane_calibration
+{
+
+Planes::Planes(const int& count, const CalibrationParameters::Parameters& parameters,
+               const PlaneToDepthImage& plane_to_depth) :
+    plane_to_depth_(plane_to_depth)
+{
+  pair_count_ = count;
+  max_deviation_ = parameters.max_deviation_;
+
+  translation_ = Eigen::Translation3d(parameters.ground_plane_offset_);
+  base_rotation_ = parameters.rotation_;
+
+  makePlanes();
+}
+
+void Planes::makePlanes()
+{
+  // max_deviation_ * 2 for plus / minus
+  double angle_step_size = max_deviation_ / pair_count_;
+  double angle = max_deviation_;
+
+  for (int i = 0; i < pair_count_; ++i)
+  {
+    if (angle == 0.0)
+    {
+      continue;
+    }
+
+    addPlanePairs(angle);
+    angle -= angle_step_size;
+  }
+}
+
+void Planes::addPlanePairs(const double& angle)
+{
+  addPlanes(angle);
+  addPlanes(-angle);
+}
+
+void Planes::addPlanes(const double& angle)
+{
+  Eigen::Vector2d angles_x(angle, 0.0);
+  MatrixPlanePtr plane_x = std::make_shared<Eigen::MatrixXf>(makePlane(angles_x));
+  x_planes_.insert(std::pair<double, MatrixPlanePtr>(angle, plane_x));
+
+  Eigen::Vector2d angles_y(0.0, angle);
+  MatrixPlanePtr plane_y = std::make_shared<Eigen::MatrixXf>(makePlane(angles_y));
+  y_planes_.insert(std::pair<double, MatrixPlanePtr>(angle, plane_y));
+}
+
+Eigen::MatrixXf Planes::makePlane(const Eigen::Vector2d& angles)
+{
+  Eigen::AngleAxisd tilt_x(angles.x(), Eigen::Vector3d::UnitX());
+  Eigen::AngleAxisd tilt_y(angles.y(), Eigen::Vector3d::UnitY());
+  Eigen::Affine3d transform = translation_ * base_rotation_ * tilt_x * tilt_y;
+
+  return plane_to_depth_.convert(transform);
+}
+
+std::pair<MatrixPlanePtr, MatrixPlanePtr> Planes::getFittingXTiltPlanes(const double& angle, const double& deviation)
+{
+  return getFittingTiltPlanes(x_planes_, angle, deviation);
+}
+
+std::pair<MatrixPlanePtr, MatrixPlanePtr> Planes::getFittingYTiltPlanes(const double& angle, const double& deviation)
+{
+  return getFittingTiltPlanes(y_planes_, angle, deviation);
+}
+
+std::pair<MatrixPlanePtr, MatrixPlanePtr> Planes::getFittingTiltPlanes(const std::map<double, MatrixPlanePtr>& planes,
+                                                                       const double& angle, const double& deviation)
+{
+  std::pair<double, double> plane_indicies = getDeviationPlaneKeys(angle, deviation);
+
+  MatrixPlanePtr first = planes.at(plane_indicies.first);
+  MatrixPlanePtr second = planes.at(plane_indicies.second);
+
+  return std::pair<MatrixPlanePtr, MatrixPlanePtr>(first, second);
+}
+
+std::pair<double, double> Planes::getDeviationPlaneKeys(const double& angle, const double& deviation)
+{
+  double upper_angle = angle + deviation;
+  double lower_angle = angle - deviation;
+
+  auto upper_it = x_planes_.lower_bound(upper_angle); //maybe confusing, see official docu
+  auto lower_it = x_planes_.lower_bound(lower_angle);
+  --lower_it; //take the value lower than this
+
+  if (upper_it == x_planes_.end())
+  {
+    upper_it = x_planes_.begin();
+  }
+
+  if (lower_it == x_planes_.end())
+  {
+    --lower_it;
+  }
+
+  return std::make_pair(upper_it->first, lower_it->first);
+}
+
+} /* end namespace */

--- a/src/planes.cpp
+++ b/src/planes.cpp
@@ -6,11 +6,10 @@
 namespace plane_calibration
 {
 
-Planes::Planes(const int& count, const CalibrationParameters::Parameters& parameters,
-               const PlaneToDepthImage& plane_to_depth) :
+Planes::Planes(const CalibrationParameters::Parameters& parameters, const PlaneToDepthImage& plane_to_depth) :
     plane_to_depth_(plane_to_depth)
 {
-  pair_count_ = count;
+  pair_count_ = parameters.precomputed_plane_pairs_count_;
   max_deviation_ = parameters.max_deviation_;
 
   translation_ = Eigen::Translation3d(parameters.ground_plane_offset_);

--- a/src/planes.cpp
+++ b/src/planes.cpp
@@ -20,20 +20,19 @@ Planes::Planes(const CalibrationParameters::Parameters& parameters, const PlaneT
 
 void Planes::makePlanes()
 {
-  // max_deviation_ * 2 for plus / minus
-  double angle_step_size = max_deviation_ / pair_count_;
-  double angle = max_deviation_;
+  // When fitting a plane close to the max deviation we have to have
+  // some planes outside the max deviation borders
+  double buffer_multiplier = 2.2;
+  double angle_step_size = max_deviation_ * buffer_multiplier / pair_count_;
+  double angle = max_deviation_ * buffer_multiplier;
 
   for (int i = 0; i < pair_count_; ++i)
   {
-    if (angle == 0.0)
-    {
-      continue;
-    }
-
     addPlanePairs(angle);
     angle -= angle_step_size;
   }
+
+  addPlanes(0.0);
 }
 
 void Planes::addPlanePairs(const double& angle)


### PR DESCRIPTION
Precompute planes for calibration instead of compute on the fly to lower computation.

On the fly computation is still optional available.