### PR TITLE
Update calibration only with too low data

### DIFF
--- a/cfg/PlaneCalibration.cfg
+++ b/cfg/PlaneCalibration.cfg
@@ -4,20 +4,20 @@ from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, d
 
 gen = ParameterGenerator()
 
-gen.add("input_max_noise", double_t, 0, "Max. noise range", 0.035, 0.0, 0.1)
+gen.add("input_max_noise", double_t, 0, "Max. noise range", 0.03, 0.0, 0.1)
 gen.add("input_threshold_from_ground", double_t, 0, "Threshold from ground for valid points [temporary]", 0.15, 0.0, 0.3)
 gen.add("input_max_nan_ratio", double_t, 0, "Max. ratio of nans to consider valid input data", 0.5, 0.0, 1.0)
 gen.add("input_max_zero_ratio", double_t, 0, "Max. ratio of zeros to consider valid input data", 0.5, 0.0, 1.0)
-gen.add("input_min_data_ratio", double_t, 0, "Min. ratio of valid overall data to consider valid input data", 0.6, 0.0, 1.0)
+gen.add("input_min_data_ratio", double_t, 0, "Min. ratio of valid overall data to consider valid input data", 0.7, 0.0, 1.0)
 
 gen.add("max_deviation_degrees", double_t, 0, "Max. deviation of the ground plane orientation [degree]", 6.0, 0.0, 14.0)
 gen.add("iterations", int_t, 0, "Iterations to optimize estimation", 4, 0, 20)
 
 gen.add("precompute_planes", bool_t, 0, "Precompute planes for fitting or calculate on the fly", True)
-gen.add("precomputed_plane_pairs_count", int_t, 0, "Iterations to optimize estimation", 20, 1, 100)
+gen.add("precomputed_plane_pairs_count", int_t, 0, "Iterations to optimize estimation", 40, 1, 200)
 
-gen.add("plane_max_too_low_ratio", double_t, 0, "[Validation] Max. ratio of points lower than given ground plane to consider fitting the data", 0.12, 0.0, 1.0)
-gen.add("plane_max_mean", double_t, 0, "[Validation] Max. mean data point abs. distance to given ground plane to consider fitting the data", 0.024, 0.0, 0.2)
+gen.add("plane_max_too_low_ratio", double_t, 0, "[Validation] Max. ratio of points lower than given ground plane to consider fitting the data", 0.02, 0.0, 1.0)
+gen.add("plane_max_mean", double_t, 0, "[Validation] Max. mean data point abs. distance to given ground plane to consider fitting the data", 0.03, 0.0, 0.2)
 
 gen.add("debug", bool_t, 0, "Show debug things, e.g. tf transforms", False)
 gen.add("use_manual_ground_transform", bool_t, 0, "Use the settings below for the ground plane transformation", False)

--- a/include/plane_calibration/calibration_validation.hpp
+++ b/include/plane_calibration/calibration_validation.hpp
@@ -37,8 +37,14 @@ public:
 
   bool angleOffsetValid(const std::pair<double, double>& angles);
   bool groundPlaneFitsData(const Eigen::MatrixXf& ground_plane, const Eigen::MatrixXf& data, const bool& debug = false);
+  bool groundPlaneHasDataBelow(const Eigen::MatrixXf& ground_plane, const Eigen::MatrixXf& data, const bool& debug =
+                                   false);
 
 protected:
+  void getDifferenceAndNotNanCount(const Eigen::MatrixXf& ground_plane, const Eigen::MatrixXf& data,
+                                   Eigen::MatrixXf& difference, int& not_nan_count);
+  bool checkTooLow(const Eigen::MatrixXf& difference, const int& not_nan_count, double& too_low_ratio);
+
   mutable std::mutex mutex_;
   CameraModel camera_model_;
   CalibrationParametersPtr parameters_;

--- a/params/defaults.yaml
+++ b/params/defaults.yaml
@@ -1,4 +1,4 @@
 calibration_rate:           1.0
 ground_frame:               base_footprint
 precompute_planes:         true
-precomputed_plane_pairs_count:  20
+precomputed_plane_pairs_count:  40

--- a/src/plane_calibration_nodelet.cpp
+++ b/src/plane_calibration_nodelet.cpp
@@ -306,9 +306,9 @@ void PlaneCalibrationNodelet::runCalibration(Eigen::MatrixXf depth_matrix)
   if (!always_update_ && last_valid_calibration_result_plane_.size() != 0)
   {
     bool parameters_updated = calibration_parameters_->parametersUpdated();
-    bool last_calibration_is_still_good = calibration_validation_->groundPlaneFitsData(
+    bool last_calibration_gone_bad = calibration_validation_->groundPlaneHasDataBelow(
         last_valid_calibration_result_plane_, depth_matrix, debug_);
-    if (!parameters_updated && last_calibration_is_still_good)
+    if (!parameters_updated && !last_calibration_gone_bad)
     {
       if (debug_)
       {


### PR DESCRIPTION
Only trigger new calibration if we get data which is too low (-> ground plane is tilted).

This removes triggering when the ground is occluded.